### PR TITLE
remove quotations from run_ansible.sh of inventory variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           at: ./ #full contents of workspace are downloaded and copied into root directory
       - run: #curl fetches terraform version .zip
           name: Install dependencies #required by ansible scripts
-          command: apk add ansible bash curl jq cat
+          command: apk add ansible bash curl jq
       - run:
           name: Install terraform
           command: |

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Choice of AWS is due to personal preference not due to AWS being better than ano
 Cloud infra is written as Infrastructure as Code (IaC), using a cloud agnostic language, HashiCorp Configuration Language (HCL), which is executed using HashiCorp Terraform CLI tool. The purpose of IaC is to manage state of the deployed resources by tracking or reverting any configuration drift in the environment. This ensures test and production are close as they can be so that deployment to production has less risk of issues popping up
 
 **Advantageous Scenarios:**
-- By deploying and destroying infrastructure using code, predefined patterns can be created to stand up the application infra and stamp out new environments on demand in a short timespan
-- Ease to deploy infrastructure on different cloud providers with all the same tools because only cloud specific configuration alterations are required
+- By deploying and destroying in IaC, predefined patterns can be created to stand up the application's infra and stamp out new environments on demand in a short timespan
+- Ease to deploy infra on different cloud providers with all the same tools because only cloud specific configuration alterations are required
 
 ### Configuration Management Overview (Ansible)
 
@@ -129,12 +129,12 @@ Ensure **REMOTE BACKEND INFRA** step from local setup is completed and all steps
 To see a fully configured & operational application on AWS through CircleCI CD Pipeline:
 - push into a branch & merge pull request to trigger the master branch or manually trigger the pipeline build in CircleCI (local terraform version should be same as image version)
 - when the pipeline completes scaffold-infra job, note down alb_endpoint in CircleCI output
-- once the pipeline has finished, paste alb_endpoint noted down earlier into a browser
+- once pipeline has finished, paste alb_endpoint noted down earlier into a browser
 
 # Cleanup Instructions
 
 To destroy the application and associated cloud infra:
-- change current directory to within infra folder & make init to access remote state file
+- change current directory to within infra folder & `make init` to access remote state file
 - IF Error: Invalid legacy provider address, `terraform state replace-provider -- -/aws hashicorp/aws` to update provider in state file by upgrading the syntax. Re-run `make init`
 - `make down` (able to delete infra locally because local is connected to remote backend)
 

--- a/ansible/run_ansible.sh
+++ b/ansible/run_ansible.sh
@@ -16,11 +16,11 @@ cat << EOF > inventory.yml
 all: 
     hosts:
         ${HOSTS_IP}:
-            db_username_i: "${DB_USER}" 
-            db_password_i: "${DB_PASS}" 
-            db_name_i: "${DB_NAME}"
-            db_port_i: "${DB_PORT}"
-            db_host_i: "${DB_HOST}"
+            db_username_i: ${DB_USER} 
+            db_password_i: ${DB_PASS} 
+            db_name_i: ${DB_NAME}
+            db_port_i: ${DB_PORT}
+            db_host_i: ${DB_HOST}
 EOF
 
 FILE=~/.ssh/ServianSSHKeyPair

--- a/infra/README.md
+++ b/infra/README.md
@@ -32,7 +32,7 @@ VPC is configured with 3 layers across 3 availability zones, amounting to 9 subn
 
 ## 3 Layer Infrastructure
 
-`sg.tf` : Each layer has security groups setup to limit access, acting as software defined firewalls. This define which connections are allowed in and on which ports (ingress), as well as outgoing (egress). So that, infrastructure is configured for restricted access, only allowing explicit connections by denying unpermitted access
+`sg.tf` : Each layer has security groups setup to limit access, acting as software defined firewalls. This define which connections are allowed in and on which ports (ingress), as well as outgoing (egress). So that, infra is configured for restricted access, only allowing explicit connections by denying unpermitted access
 
 ### Load Balancer (Public Layer)
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region  = "us-east-1"
+  region = "us-east-1"
 }
 
 #configure terraform to store state in s3 bucket with encryption and locking

--- a/infra/makefile
+++ b/infra/makefile
@@ -5,9 +5,9 @@ init: #validate backend config and create statefile if doesn't exist
 #to download and make environment ready accordingly
 	terraform init
 
-#give access to value directly - clean string
-albendpoint: #pbcopy copies string of the value
-	terraform output alb_endpoint | pbcopy
+#access value directly - clean string (remove " start & end)
+albendpoint: #prints string with no extra escaping or whitespace & copy value
+	terraform output -raw alb_endpoint | pbcopy
 
 up: #validate code, format indentations & styling correctly and deploy
 	terraform validate


### PR DESCRIPTION
double quotations cause parsing error of inventory file generation